### PR TITLE
fix rawNameWOExt in BaseSimilarityEvaluator.cs

### DIFF
--- a/Assets/ICE/Scripts/Evaluation/Similarity/BaseSimilarityEvaluator.cs
+++ b/Assets/ICE/Scripts/Evaluation/Similarity/BaseSimilarityEvaluator.cs
@@ -95,7 +95,7 @@ namespace ICE.Evaluation
 
                 string outputName = outputFiles[i];
                 string outputNameWOExt = Path.GetFileNameWithoutExtension(outputName);
-                string rawNameWOExt = string.Format("{0}_raw.png", outputNameWOExt);
+                string rawNameWOExt = string.Format("{0}_raw", outputNameWOExt);
                 string rawOutputName = outputName.Replace(outputNameWOExt, rawNameWOExt);
 
                 AdjustCamera(sBound);


### PR DESCRIPTION
## Description

When I `select ICE > Evaluation > Batched > Similarity test` in Unity, the name of the generated image file is `{file_name}_raw.png.png`.

This is probably because the .png extension is added in `rawNameWOExt`.

We have removed that in this PR.
